### PR TITLE
Add NotFair under Production-Ready Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Production-ready MCP implementations maintained by platform providers.
 * [Neo4j](https://github.com/neo4j-contrib/mcp-neo4j/) - A Neo4j graph database server supporting schema, read/write Cypher queries, and graph database-backed memory.
 * [Neon](https://github.com/neondatabase/mcp-server-neon) - MCP server to interact with the Neon serverless Postgres platform.
 * [Netlify](https://docs.netlify.com/welcome/build-with-ai/netlify-mcp-server/) - A platform to create, build, deploy, and manage your websites with the Netlify web platform.
+* [NotFair](https://notfair.co) - A hosted Google Ads MCP server for Claude and other AI agents to diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API with a built-in human-approval gate.
 * [Notion](https://github.com/makenotion/notion-mcp-server#readme) - MCP server implementation for the Notion API.
 * [OceanBase](https://github.com/oceanbase/mcp-oceanbase) - MCP server for the OceanBase database and its tools.
 * [Octagon](https://github.com/OctagonAI/octagon-mcp-server) - A platform delivering real-time investment research with extensive private and public market data.


### PR DESCRIPTION
Adding NotFair under Production-Ready Servers, alphabetically between Netlify and Notion.

NotFair is a hosted Google Ads MCP server that lets Claude and other AI agents connect to a Google Ads account, diagnose campaign performance, recommend optimizations, and execute approved changes via the official Google Ads API. There's a built-in human-approval gate for any mutation, and a free tier (no credit card required).

Linked to the product page since NotFair is a hosted service without a public source repo, similar to existing entries like Chiki StudIO and Netlify. Happy to adjust the wording or placement.