### PR TITLE
Add Tuning Engines governed runtime MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Production-ready MCP implementations maintained by platform providers.
 * [TiDB](https://github.com/pingcap/pytidb) - MCP server to interact with the TiDB database platform.
 * [Tinybird](https://github.com/tinybirdco/mcp-tinybird) - MCP server to interact with the Tinybird serverless ClickHouse platform.
 * [Tldv](https://gitlab.com/tldv/tldv-mcp-server) - A connector for AI agents to Google Meet, Zoom & Microsoft Teams through [tldv](https://tldv.io)
+* [Tuning Engines](https://github.com/cerebrixos-org/tuning-engines-cli) - Govern model, agent, skill, and MCP workflows with policy controls, approvals, traces, and usage analytics. Install with `npx -y --package tuningengines-cli@latest te mcp serve`.
 * [UnifAI](https://github.com/unifai-network/unifai-mcp-server) - A platform to dynamically search and call tools using [UnifAI Network](https://unifai.network)
 * [Unstructured](https://github.com/Unstructured-IO/UNS-MCP) - A system to set up and interact with your unstructured data processing workflows on the [Unstructured Platform](https://unstructured.io)
 * [Upstash](https://github.com/upstash/mcp-server) - A service to manage Redis databases and run Redis commands on Upstash [Upstash](https://upstash.com/) with natural language.


### PR DESCRIPTION
Thank you for curating this production-ready MCP list. This adds Tuning Engines as a public npm-backed MCP server for governing model, agent, skill, and MCP workflows with policy controls, approvals, traces, and usage analytics. The entry follows the existing alphabetical layout and includes the copy-paste `npx` install command.